### PR TITLE
Add workflow for packing and publishing steamworks Steamworks.NET.AnyCPU

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -7,9 +7,6 @@ on:
         required: false
         type: string
   push:
-    branches:
-      - main
-      - anycpu-2
     tags:
       - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*" # Matches YYYY.*.* format like 2025.162.5
       - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*-*" # Matches YYYY.*.*-* format like 2025.162.5-beta1
@@ -42,9 +39,11 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.version }}"
             echo "Using manual version: $VERSION"
-          else
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
             echo "Using tag version: $VERSION"
+          else
+            VERSION=""
           fi
           
           # Set default version if empty
@@ -86,7 +85,7 @@ jobs:
         uses: NuGet/login@v1
         id: login
         with:
-          user: vars.NUGET_USER # Set this variable in workflows > vars
+          user: ${{ vars.NUGET_USER }} # Set this variable in workflows > vars
 
       - name: NuGet push
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,4 +1,4 @@
-name: Build & Publish Package
+name: Build & Publish Steamworks.NET.AnyCPU
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,35 +1,43 @@
 name: Build & Publish Package
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version (e.g., 2025.162.1)'
+        required: true
+        type: string
+      publish:
+        description: 'Publish to nuget.org?'
+        required: false
+        type: boolean
 
-# Uncomment to enable OIDC authentication for nuget publishing
-# permissions:
-#   id-token: write   # Required for OIDC authentication
-#   contents: read    # Required to checkout code
+permissions:
+  id-token: write   # Required for OIDC authentication
+  contents: read    # Required to checkout code
 
 jobs:
-  restore_build_pack_and_publish:
-    name: Restore, Build, Pack and Publish
+  build:
+    name: Pack and create artifact
     runs-on: ubuntu-latest
-
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           lfs: true
 
-      - name: Set up .net
+      - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             8.0.x
 
-      - name: restore, build, pack Steamworks.NET.AnyCPU
+      - name: Pack Steamworks.NET.AnyCPU
         run: |
           dotnet pack ./Standalone3.0/Steamworks.NET.csproj \
-            --configuration Release 
+            --configuration Release \
+            -p:Version=${{ github.event.inputs.version }}
 
-      # Upload the NuGet package as an artifact
       - name: Upload NuGet package artifact
         uses: actions/upload-artifact@v4
         with:
@@ -37,14 +45,24 @@ jobs:
           path: ./Standalone3.0/bin/Release/*.nupkg
           retention-days: 30
 
-    # Uncomment the following steps to enable publishing to NuGet.org
-    # Get a short-lived NuGet API key
-    #   - name: NuGet login (OIDC → temp API key)
-    #     uses: NuGet/login@v1
-    #     id: login
-    #     with:
-    #       user: vars.NUGET_USER # Set this variable in workflows > vars
+  publish:
+    name: Publish to nuget.org
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.inputs.publish == 'true' }}
+    
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-package
+          path: ./packages
+
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: vars.NUGET_USER # Set this variable in workflows > vars
       
-    #   # Push the package
-    #   - name: NuGet push
-    #     run: dotnet nuget push ./Standalone3.0/bin/Release/*.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+      - name: NuGet push
+        run: dotnet nuget push ./packages/*.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -46,6 +46,13 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/}
             echo "Using tag version: $VERSION"
           fi
+          
+          # Set default version if empty
+          if [ -z "$VERSION" ] || [ "$VERSION" = "" ]; then
+            VERSION="0.0.0"
+            echo "Version was empty, using default: $VERSION"
+          fi
+          
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Pack Steamworks.NET.AnyCPU
@@ -66,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: prod
     needs: build
-    if: needs.build.outputs.version != ''
+    if: needs.build.outputs.version != '0.0.0'
 
     steps:
       - name: Download artifact

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,23 +3,27 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Package version (e.g., 2025.162.1)'
-        required: true
-        type: string
-      publish:
-        description: 'Publish to nuget.org?'
+        description: "Package version (e.g., 2025.162.1)"
         required: false
-        type: boolean
+        type: string
+  push:
+    branches:
+      - main
+      - anycpu-2
+    tags:
+      - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*" # Matches YYYY.*.* format like 2025.162.5
+      - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*-*" # Matches YYYY.*.*-* format like 2025.162.5-beta1
 
 permissions:
-  id-token: write   # Required for OIDC authentication
-  contents: read    # Required to checkout code
+  id-token: write # Required for OIDC authentication
+  contents: read # Required to checkout code
 
 jobs:
   build:
     name: Pack and create artifact
     runs-on: ubuntu-latest
-    
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,11 +36,23 @@ jobs:
           dotnet-version: |
             8.0.x
 
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+            echo "Using manual version: $VERSION"
+          else
+            VERSION=${GITHUB_REF#refs/tags/}
+            echo "Using tag version: $VERSION"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Pack Steamworks.NET.AnyCPU
         run: |
           dotnet pack ./Standalone3.0/Steamworks.NET.csproj \
             --configuration Release \
-            -p:Version=${{ github.event.inputs.version }}
+            -p:Version=${{ steps.version.outputs.version }}
 
       - name: Upload NuGet package artifact
         uses: actions/upload-artifact@v4
@@ -46,11 +62,12 @@ jobs:
           retention-days: 30
 
   publish:
-    name: Publish to nuget.org
+    name: Publish ${{ needs.build.outputs.version }} to nuget.org
     runs-on: ubuntu-latest
+    environment: prod
     needs: build
-    if: ${{ github.event.inputs.publish == 'true' }}
-    
+    if: needs.build.outputs.version != ''
+
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -63,6 +80,7 @@ jobs:
         id: login
         with:
           user: vars.NUGET_USER # Set this variable in workflows > vars
-      
+
       - name: NuGet push
-        run: dotnet nuget push ./packages/*.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+        run: |
+          dotnet nuget push ./packages/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,50 @@
+name: Build & Publish Package
+on:
+  workflow_dispatch:
+
+# Uncomment to enable OIDC authentication for nuget publishing
+# permissions:
+#   id-token: write   # Required for OIDC authentication
+#   contents: read    # Required to checkout code
+
+jobs:
+  restore_build_pack_and_publish:
+    name: Restore, Build, Pack and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up .net
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+
+      - name: restore, build, pack Steamworks.NET.AnyCPU
+        run: |
+          dotnet pack ./Standalone3.0/Steamworks.NET.csproj \
+            --configuration Release 
+
+      # Upload the NuGet package as an artifact
+      - name: Upload NuGet package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-package
+          path: ./Standalone3.0/bin/Release/*.nupkg
+          retention-days: 30
+
+    # Uncomment the following steps to enable publishing to NuGet.org
+    # Get a short-lived NuGet API key
+    #   - name: NuGet login (OIDC → temp API key)
+    #     uses: NuGet/login@v1
+    #     id: login
+    #     with:
+    #       user: vars.NUGET_USER # Set this variable in workflows > vars
+      
+    #   # Push the package
+    #   - name: NuGet push
+    #     run: dotnet nuget push ./Standalone3.0/bin/Release/*.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Adds a simple workflow for packing the Steamworks.NET.AnyCPU nuget package and publishing it to nuget.org. Currently only run on manual run of the workflow.

The workflow uses nuget.org's newer [trusted publishing ](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) so there is a step for the owner of the nuget package on nuget.org to do as well as the action variable of NUGET_USER. Its not a secret but this allows another to use the action without it hard coded. Ideally, we get to be able to publish a beta branch through the workflow to make sure it works.

Some questions:
- How should versioning be handled?
   - On nuget you cannot push the same version twice so getting versioning right can be sort of important
   - Currently the workflow sets the versioning up through the action input. Which is good enough but prone to user input error
   - It looks like releases on the steamworks.net repo get tagged so perhaps we do a tag specific to steamworks.net.anycpu push when we want the version to change?
- We can add a manual approval step of certain users instead of the input boolean of  the 'publish' variable
- We could probably also create packages for the other versions of the repository as well even if they won't cross compile at least they will be available for people to download. Do we want to do that as well?