### PR TITLE
Change the place of DLL resolve hook

### DIFF
--- a/CodeGen/templates/nativemethods.txt
+++ b/CodeGen/templates/nativemethods.txt
@@ -37,6 +37,42 @@ using IntPtr = System.IntPtr;
 namespace Steamworks {
 	[System.Security.SuppressUnmanagedCodeSecurity()]
 	internal static class NativeMethods {
+	#if STEAMWORKS_ANYCPU
+		static NativeMethods() {
+			NativeLibrary.SetDllImportResolver(typeof(NativeMethods).Assembly, DllImportResolver);
+		}
+
+		private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath) {
+			// check is requesting library name matches steam native
+			// we don't check requester here because we want to ensure we are the first loader of steam native
+			// otherwise other libraries may have already loaded steam native with wrong architecture
+			if ((libraryName == NativeLibraryName || libraryName == NativeLibrary_SDKEncryptedAppTicket)
+				// check are we on win64, the special case we are going to handle
+				&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess) {
+				// check who is requesting steam native
+				if (assembly.GetName().Name != "Steamworks.NET") {
+					// Unmanaged libraries(steam native dll) will be cached(probably by name),
+					// we warn developers here the steam native will be cached for any later loads, this is a potentional pollution.
+					System.Diagnostics.Debug.WriteLine(
+						$"[Warning] Assembly {assembly.GetName().Name} is requesting Steam native by it's original name, " +
+						$"but Steamworks.NET.AnyCPU want to load x64 version of steam library \"{libraryName}\". The loaded Steam native will be cached " +
+						$"and may potentially break it.\n" +
+						$"Affected assembly's full name: {assembly.FullName}");
+
+					return 0;
+				}
+
+				// platform specific suffix is not needed, to reuse default unmanaged dependencies resolve logic
+				string x64LibName = $"{libraryName}64";
+				// we don't care failed load, let next handler manage it
+				NativeLibrary.TryLoad(x64LibName, assembly, searchPath, out nint lib);
+				return lib;
+			}
+
+			return 0;
+		}
+#endif
+
 #if STEAMWORKS_WIN && STEAMWORKS_X64
 		internal const string NativeLibraryName = "steam_api64";
 		internal const string NativeLibrary_SDKEncryptedAppTicket = "sdkencryptedappticket64";

--- a/Standalone3.0/Steamworks.NET.csproj
+++ b/Standalone3.0/Steamworks.NET.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>Steamworks</RootNamespace>
 		<RepositoryType>git</RepositoryType>
-		<DefineConstants>STEAMWORKS_LIN_OSX;STEAMWORKS_X64;STEAMWORKS_ANYCPU</DefineConstants>
+		<DefineConstants>STEAMWORKS_WIN;STEAMWORKS_LIN_OSX;STEAMWORKS_X64;STEAMWORKS_ANYCPU</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Label="Nuget PM">

--- a/Standalone3.0/Steamworks.NET.csproj
+++ b/Standalone3.0/Steamworks.NET.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>Steamworks</RootNamespace>
 		<RepositoryType>git</RepositoryType>
-		<DefineConstants>STEAMWORKS_WIN;STEAMWORKS_LIN_OSX;STEAMWORKS_X64;STEAMWORKS_ANYCPU</DefineConstants>
+		<DefineConstants>STEAMWORKS_LIN_OSX;STEAMWORKS_X64;STEAMWORKS_ANYCPU</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Label="Nuget PM">

--- a/com.rlabrecque.steamworks.net/Runtime/Steam.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/Steam.cs
@@ -14,59 +14,6 @@ using System.Runtime.InteropServices;
 using IntPtr = System.IntPtr;
 
 namespace Steamworks {
-#if STEAMWORKS_ANYCPU // implies .net 8.0 and STEAMWORKS_X86
-	internal static class AnyCPU
-	{
-		internal static void BeCompatible()
-		{
-            // not checking os or arch etc, this library can act as a placeholder
-
-            if (s_isAnyCPUHookApplied)
-				return;
-
-			s_isAnyCPUHookApplied = true;
-			System.Runtime.Loader.AssemblyLoadContext.Default.ResolvingUnmanagedDll += SteamNativeResolveHook;
-		}
-
-		private static bool s_isAnyCPUHookApplied = false;
-
-		private static nint SteamNativeResolveHook(System.Reflection.Assembly requestAsm, string name)
-		{
-			// check is requesting library name matches steam native
-			// we don't check requester here because we want to ensure we are the first loader of steam native
-			// otherwise other libraries may have already loaded steam native with wrong architecture
-			if ((name == NativeMethods.NativeLibraryName || name == NativeMethods.NativeLibrary_SDKEncryptedAppTicket)
-				// check are we on win64, the special case we are going to handle
-				&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess)
-			{
-				// check who is requesting steam native
-				if (requestAsm.GetName().Name != "Steamworks.NET")
-				{
-					// document of ALC says unmanaged libraries(steam native dll) will be cached(probably by name),
-					// we warn developers here the steam native will be cached for any later loads, this is a potentional pollution.
-					System.Diagnostics.Debug.WriteLine(
-						$"[Warning] Assembly {requestAsm.GetName().Name} is requesting Steam native by it's original name, " +
-						$"but Steamworks.NET.AnyCPU want to load x64 version of steam library \"{name}\". The loaded Steam native will be cached " +
-						$"and may potentially break it.\n" +
-						$"Affected assembly's full name: {requestAsm.FullName}");
-					
-					return 0;
-				}
-
-				// platform specific suffix is not needed, to reuse default unmanaged dependencies resolve logic
-				string x64LibName = $"{name}64";
-				// we don't care failed load, let next handler manage it
-				NativeLibrary.TryLoad(x64LibName, requestAsm, null, out nint lib);
-				return lib;
-			}
-
-			return 0;
-		}
-	}
-#endif
-
-
-
 	public static class SteamAPI {
 		//----------------------------------------------------------------------------------------------------------------------------------------------------------//
 		//	Steam API setup & shutdown
@@ -108,9 +55,6 @@ namespace Steamworks {
 		// Returns true on success
 		public static ESteamAPIInitResult InitEx(out string OutSteamErrMsg)
 		{
-#if STEAMWORKS_ANYCPU
-			AnyCPU.BeCompatible();
-#endif
 			InteropHelp.TestIfPlatformSupported();
 
 			var pszInternalCheckInterfaceVersions = new System.Text.StringBuilder();
@@ -167,9 +111,6 @@ namespace Steamworks {
 		}
 
 		public static bool Init() {
-#if STEAMWORKS_ANYCPU
-			AnyCPU.BeCompatible();
-#endif
 			InteropHelp.TestIfPlatformSupported();
 
 			string SteamErrorMsg;
@@ -195,9 +136,6 @@ namespace Steamworks {
 		// NOTE: If you use the Steam DRM wrapper on your primary executable file, this check is unnecessary
 		// since the DRM wrapper will ensure that your application was launched properly through Steam.
 		public static bool RestartAppIfNecessary(AppId_t unOwnAppID) {
-#if STEAMWORKS_ANYCPU
-			AnyCPU.BeCompatible();
-#endif
 			InteropHelp.TestIfPlatformSupported();
 			return NativeMethods.SteamAPI_RestartAppIfNecessary(unOwnAppID);
 		}
@@ -289,9 +227,6 @@ namespace Steamworks {
 		// - The version string should be in the form x.x.x.x, and is used by the master server to detect when the
 		//		server is out of date.  (Only servers with the latest version will be listed.)
 		public static ESteamAPIInitResult InitEx(uint unIP, ushort usGamePort, ushort usQueryPort, EServerMode eServerMode, string pchVersionString, out string OutSteamErrMsg) {
-#if STEAMWORKS_ANYCPU
-			AnyCPU.BeCompatible();
-#endif
 			InteropHelp.TestIfPlatformSupported();
 
 			var pszInternalCheckInterfaceVersions = new System.Text.StringBuilder();
@@ -335,9 +270,6 @@ namespace Steamworks {
 		// This function is included for compatibility with older SDK.
 		// You can use it if you don't care about decent error handling
 		public static bool Init(uint unIP, ushort usGamePort, ushort usQueryPort, EServerMode eServerMode, string pchVersionString) {
-#if STEAMWORKS_ANYCPU
-			AnyCPU.BeCompatible();
-#endif
 			InteropHelp.TestIfPlatformSupported();
 
 			string SteamErrorMsg;

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
@@ -37,6 +37,36 @@ using IntPtr = System.IntPtr;
 namespace Steamworks {
 	[System.Security.SuppressUnmanagedCodeSecurity()]
 	internal static class NativeMethods {
+#if STEAMWORKS_ANYCPU
+		static NativeMethods()
+		{
+			NativeLibrary.SetDllImportResolver(typeof(NativeMethods).Assembly, DllImportResolver);
+		}
+
+		private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
+		{
+			// Only handle steam_api libraries
+			if (libraryName != "steam_api" && libraryName != "steam_api64" && 
+			    libraryName != "sdkencryptedappticket" && libraryName != "sdkencryptedappticket64")
+			{
+				return IntPtr.Zero;
+			}
+
+			// On Windows x64, use steam_api64
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess)
+			{
+				string libName = libraryName.Contains("encrypted") ? "sdkencryptedappticket64" : "steam_api64";
+				if (NativeLibrary.TryLoad(libName, assembly, searchPath, out IntPtr handle))
+				{
+					return handle;
+				}
+			}
+
+			// For all other platforms, let .NET's default RID-based resolution handle it
+			return IntPtr.Zero;
+		}
+#endif
+
 #if STEAMWORKS_WIN && STEAMWORKS_X64
 		internal const string NativeLibraryName = "steam_api64";
 		internal const string NativeLibrary_SDKEncryptedAppTicket = "sdkencryptedappticket64";

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
@@ -45,25 +45,35 @@ namespace Steamworks {
 
 		private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
 		{
-			// Only handle steam_api libraries
-			if (libraryName != "steam_api" && libraryName != "steam_api64" && 
-			    libraryName != "sdkencryptedappticket" && libraryName != "sdkencryptedappticket64")
+			// check is requesting library name matches steam native
+			// we don't check requester here because we want to ensure we are the first loader of steam native
+			// otherwise other libraries may have already loaded steam native with wrong architecture
+			if ((libraryName == NativeLibraryName || libraryName == NativeLibrary_SDKEncryptedAppTicket)
+				// check are we on win64, the special case we are going to handle
+				&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess)
 			{
-				return IntPtr.Zero;
-			}
-
-			// On Windows x64, use steam_api64
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess)
-			{
-				string libName = libraryName.Contains("encrypted") ? "sdkencryptedappticket64" : "steam_api64";
-				if (NativeLibrary.TryLoad(libName, assembly, searchPath, out IntPtr handle))
+				// check who is requesting steam native
+				if (assembly.GetName().Name != "Steamworks.NET")
 				{
-					return handle;
+					// Unmanaged libraries(steam native dll) will be cached(probably by name),
+					// we warn developers here the steam native will be cached for any later loads, this is a potentional pollution.
+					System.Diagnostics.Debug.WriteLine(
+						$"[Warning] Assembly {assembly.GetName().Name} is requesting Steam native by it's original name, " +
+						$"but Steamworks.NET.AnyCPU want to load x64 version of steam library \"{libraryName}\". The loaded Steam native will be cached " +
+						$"and may potentially break it.\n" +
+						$"Affected assembly's full name: {assembly.FullName}");
+
+					return 0;
 				}
+
+				// platform specific suffix is not needed, to reuse default unmanaged dependencies resolve logic
+				string x64LibName = $"{libraryName}64";
+				// we don't care failed load, let next handler manage it
+				NativeLibrary.TryLoad(x64LibName, assembly, searchPath, out nint lib);
+				return lib;
 			}
 
-			// For all other platforms, let .NET's default RID-based resolution handle it
-			return IntPtr.Zero;
+			return 0;
 		}
 #endif
 

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
@@ -37,24 +37,20 @@ using IntPtr = System.IntPtr;
 namespace Steamworks {
 	[System.Security.SuppressUnmanagedCodeSecurity()]
 	internal static class NativeMethods {
-#if STEAMWORKS_ANYCPU
-		static NativeMethods()
-		{
+	#if STEAMWORKS_ANYCPU
+		static NativeMethods() {
 			NativeLibrary.SetDllImportResolver(typeof(NativeMethods).Assembly, DllImportResolver);
 		}
 
-		private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
-		{
+		private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath) {
 			// check is requesting library name matches steam native
 			// we don't check requester here because we want to ensure we are the first loader of steam native
 			// otherwise other libraries may have already loaded steam native with wrong architecture
 			if ((libraryName == NativeLibraryName || libraryName == NativeLibrary_SDKEncryptedAppTicket)
 				// check are we on win64, the special case we are going to handle
-				&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess)
-			{
+				&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess) {
 				// check who is requesting steam native
-				if (assembly.GetName().Name != "Steamworks.NET")
-				{
+				if (assembly.GetName().Name != "Steamworks.NET") {
 					// Unmanaged libraries(steam native dll) will be cached(probably by name),
 					// we warn developers here the steam native will be cached for any later loads, this is a potentional pollution.
 					System.Diagnostics.Debug.WriteLine(


### PR DESCRIPTION
Seemingly fixes #5. Unsure of all the impacts it might have? But, godot was not loading steamworks correctly without this when using AnyCPU 