### PR TITLE
Manual pack aware send signal

### DIFF
--- a/CodeGen/templates/nativemethods.txt
+++ b/CodeGen/templates/nativemethods.txt
@@ -37,6 +37,42 @@ using IntPtr = System.IntPtr;
 namespace Steamworks {
 	[System.Security.SuppressUnmanagedCodeSecurity()]
 	internal static class NativeMethods {
+	#if STEAMWORKS_ANYCPU
+		static NativeMethods() {
+			NativeLibrary.SetDllImportResolver(typeof(NativeMethods).Assembly, DllImportResolver);
+		}
+
+		private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath) {
+			// check is requesting library name matches steam native
+			// we don't check requester here because we want to ensure we are the first loader of steam native
+			// otherwise other libraries may have already loaded steam native with wrong architecture
+			if ((libraryName == NativeLibraryName || libraryName == NativeLibrary_SDKEncryptedAppTicket)
+				// check are we on win64, the special case we are going to handle
+				&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess) {
+				// check who is requesting steam native
+				if (assembly.GetName().Name != "Steamworks.NET") {
+					// Unmanaged libraries(steam native dll) will be cached(probably by name),
+					// we warn developers here the steam native will be cached for any later loads, this is a potentional pollution.
+					System.Diagnostics.Debug.WriteLine(
+						$"[Warning] Assembly {assembly.GetName().Name} is requesting Steam native by it's original name, " +
+						$"but Steamworks.NET.AnyCPU want to load x64 version of steam library \"{libraryName}\". The loaded Steam native will be cached " +
+						$"and may potentially break it.\n" +
+						$"Affected assembly's full name: {assembly.FullName}");
+
+					return 0;
+				}
+
+				// platform specific suffix is not needed, to reuse default unmanaged dependencies resolve logic
+				string x64LibName = $"{libraryName}64";
+				// we don't care failed load, let next handler manage it
+				NativeLibrary.TryLoad(x64LibName, assembly, searchPath, out nint lib);
+				return lib;
+			}
+
+			return 0;
+		}
+#endif
+
 #if STEAMWORKS_WIN && STEAMWORKS_X64
 		internal const string NativeLibraryName = "steam_api64";
 		internal const string NativeLibrary_SDKEncryptedAppTicket = "sdkencryptedappticket64";

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
@@ -343,6 +343,10 @@ namespace Steamworks {
 		[return: MarshalAs(UnmanagedType.I1)]
 		public static extern bool SteamAPI_ISteamNetworkingConnectionSignaling_SendSignal(ref ISteamNetworkingConnectionSignaling self, HSteamNetConnection hConn, ref SteamNetConnectionInfo_t info, IntPtr pMsg, int cbMsg);
 
+		[DllImport(NativeLibraryName, EntryPoint = "SteamAPI_ISteamNetworkingConnectionSignaling_SendSignal", CallingConvention = CallingConvention.Cdecl)]
+		[return: MarshalAs(UnmanagedType.I1)]
+		public static extern bool SteamAPI_ISteamNetworkingConnectionSignaling_SendSignal(ref ISteamNetworkingConnectionSignaling self, HSteamNetConnection hConn, ref SteamNetConnectionInfo_t_LargePack info_lp, IntPtr pMsg, int cbMsg);
+
 		[DllImport(NativeLibraryName, EntryPoint = "SteamAPI_ISteamNetworkingConnectionSignaling_Release", CallingConvention = CallingConvention.Cdecl)]
 		public static extern void SteamAPI_ISteamNetworkingConnectionSignaling_Release(ref ISteamNetworkingConnectionSignaling self);
 #endregion

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/NativeMethods.cs
@@ -37,24 +37,20 @@ using IntPtr = System.IntPtr;
 namespace Steamworks {
 	[System.Security.SuppressUnmanagedCodeSecurity()]
 	internal static class NativeMethods {
-#if STEAMWORKS_ANYCPU
-		static NativeMethods()
-		{
+	#if STEAMWORKS_ANYCPU
+		static NativeMethods() {
 			NativeLibrary.SetDllImportResolver(typeof(NativeMethods).Assembly, DllImportResolver);
 		}
 
-		private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
-		{
+		private static IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath) {
 			// check is requesting library name matches steam native
 			// we don't check requester here because we want to ensure we are the first loader of steam native
 			// otherwise other libraries may have already loaded steam native with wrong architecture
 			if ((libraryName == NativeLibraryName || libraryName == NativeLibrary_SDKEncryptedAppTicket)
 				// check are we on win64, the special case we are going to handle
-				&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess)
-			{
+				&& RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && System.Environment.Is64BitProcess) {
 				// check who is requesting steam native
-				if (assembly.GetName().Name != "Steamworks.NET")
-				{
+				if (assembly.GetName().Name != "Steamworks.NET") {
 					// Unmanaged libraries(steam native dll) will be cached(probably by name),
 					// we warn developers here the steam native will be cached for any later loads, this is a potentional pollution.
 					System.Diagnostics.Debug.WriteLine(

--- a/com.rlabrecque.steamworks.net/Runtime/autogen/SteamStructs.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/autogen/SteamStructs.cs
@@ -453,9 +453,13 @@ namespace Steamworks {
 	}
 
 	/// Describe the state of a connection.
+	#if STEAMWORKS_ANYCPU
+	[StructLayout(LayoutKind.Sequential, Pack = 8)]
+	#else
 	[StructLayout(LayoutKind.Sequential, Pack = Packsize.value)]
+	#endif
 	public struct SteamNetConnectionInfo_t {
-		
+
 		/// Who is on the other end?  Depending on the connection type and phase of the connection, we might not know
 		public SteamNetworkingIdentity m_identityRemote;
 		

--- a/com.rlabrecque.steamworks.net/Runtime/types/SteamNetworkingSockets/ISteamNetworkingConnectionSignaling.cs
+++ b/com.rlabrecque.steamworks.net/Runtime/types/SteamNetworkingSockets/ISteamNetworkingConnectionSignaling.cs
@@ -43,7 +43,15 @@ namespace Steamworks
 		/// You can assume that the same value of hConn will be used
 		/// every time.
 		public bool SendSignal(HSteamNetConnection hConn, ref SteamNetConnectionInfo_t info, IntPtr pMsg, int cbMsg) {
-			return NativeMethods.SteamAPI_ISteamNetworkingConnectionSignaling_SendSignal(ref this, hConn, ref info, pMsg, cbMsg);
+			bool ret;
+			if (!Packsize.IsLargePack) {
+				ret = NativeMethods.SteamAPI_ISteamNetworkingConnectionSignaling_SendSignal(ref this, hConn, ref info, pMsg, cbMsg);
+			} else {
+				SteamNetConnectionInfo_t info_lp = info;
+				ret = NativeMethods.SteamAPI_ISteamNetworkingConnectionSignaling_SendSignal(ref this, hConn, ref info_lp, pMsg, cbMsg);
+				info = info_lp;
+			}
+			return ret;
 		}
 
 		/// Called when the connection no longer needs to send signals.


### PR DESCRIPTION
When debugging my godot game I was noticing that the SteamNetConnectionStatusChangedCallback_t callback was giving odd/garbage data when I tried to print:

```
private void OnNetworkConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t param)
    {
        ulong steamId = param.m_info.m_identityRemote.GetSteamID64();
        ESteamNetworkingConnectionState oldStateEnum = param.m_eOldState;
        ESteamNetworkingConnectionState newStateEnum = param.m_info.m_eState;

        GD.Print($"[SteamMultiplayerPeer] Connection status changed: {oldStateEnum} -> {newStateEnum} (Steam ID: {steamId})");
    ... shortened for brevity
}
```

I ended up doing some digging and trying to fix this. These manual edits seemingly in the PR gets the SendSignal method to work properly on all CPUs. A lead on fixing #7 

Creating as a draft for as I am also trying to get the generator to make these changes instead of manually adding these changes.